### PR TITLE
user can update their comment reaction resolves #256

### DIFF
--- a/backend/notice_project/notice/models.py
+++ b/backend/notice_project/notice/models.py
@@ -18,3 +18,7 @@ class Notice:
         self.last_modified = last_modified
         # self.parent = parent
 
+class CommentReaction:
+    def __init__(self, comment_id, reaction):
+        self.comment_id = comment_id
+        self.reaction = reaction

--- a/backend/notice_project/notice/serializers.py
+++ b/backend/notice_project/notice/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from django.utils import timezone
 # import uuid
-from .models import Notice
+from .models import Notice, CommentReaction
 
 
 class CreateNoticeSerializer(serializers.Serializer):
@@ -20,3 +20,12 @@ class CreateNoticeSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         return Notice(**validated_data)
+
+
+class CommentReactionSerializer(serializers.Serializer):
+
+    comment_id = serializers.IntegerField()
+    reaction = serializers.CharField(max_length=5)
+
+    def create(self, validated_data):
+        return CommentReaction(**validated_data)

--- a/backend/notice_project/notice/urls.py
+++ b/backend/notice_project/notice/urls.py
@@ -1,18 +1,12 @@
 from django.urls import path
-from .views import sendNotice, viewNotice, setNoticeTimestamp, endpoints,CreateNoticeView
+from .views import CreateNoticeView, CommentReactionAPIView
 
 #add url routes here
 
 urlpatterns = [
 
-    path("sendNotice/", sendNotice, name="send-notice"),
-
-    path("viewNotice/", viewNotice, name="view-notice"),
-
-    path("setNoticeTimestamp/", setNoticeTimestamp, name="set-notice"),
-    
-    path("endpoints/", endpoints, name="endpoints"),
-
     path('notices/', CreateNoticeView.as_view()),
+
+    path('comment/reaction/update', CommentReactionAPIView.as_view()),
     
 ]

--- a/backend/notice_project/notice/views.py
+++ b/backend/notice_project/notice/views.py
@@ -21,13 +21,29 @@ class CommentReactionAPIView(views.APIView):
         serializer = CommentReactionSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response({
+                "success": True,
+                "data": serializer.data,
+                "message": "Your have successfully updated your reaction"
+            })
+        return Response({
+                "success": False,
+                "data": serializer.data,
+                "message": "Your hreaction could not be updated"
+            })
 
 
     def patch(self, request):
         serializer = CommentReactionSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST) 
+            return Response({
+                "success": True,
+                "data": serializer.data,
+                "message": "Your have successfully updated your reaction"
+            })
+        return Response({
+                "success": False,
+                "data": serializer.data,
+                "message": "Your hreaction could not be updated"
+            })

--- a/backend/notice_project/notice/views.py
+++ b/backend/notice_project/notice/views.py
@@ -1,9 +1,7 @@
-from django.shortcuts import render
-from django.http import JsonResponse
 from rest_framework import views
 from rest_framework import status
 from rest_framework.response import Response
-from .serializers import CreateNoticeSerializer
+from .serializers import CreateNoticeSerializer, CommentReactionSerializer
 
 
 # Create your views here.
@@ -15,51 +13,21 @@ class CreateNoticeView(views.APIView):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-  
- 
-    
-def home(request):
-    pass
-
-def endpoints(request):
-    data = {
-        "viewNotice": "http://localhost:8000/api/viewNotice/",
-        "sendNotice": "http://localhost:8000/api/sendNotice/",
-        "editTimsestamp": "http://localhost:8000/api/setNoticeTimestamp/",
-        "endpoints": "http://localhost:8000/api/endpoints/",
-    }
-
-    return JsonResponse(data, status=200)
-
-def viewNotice(request):
-    data = {
-        "id": 1,
-        "username": "Bruce Wayne",
-        "date":"24 Hours ago",
-        "timestamp": "3 Hours ago",
-        "views": "21",
-        "likes": "12",
-        "title": "App Testing Event",
-        "info": ""
-    }
-
-    return JsonResponse(data, status=200)
 
 
-def sendNotice(request):
-    data = {
-        "username": "Daniel",
-        "recipient": "ZetsuArmy",
-        "title": "Does It Work?",
-        "fileUploaded": "",
-        "message": "Yes, It Works!!!"
-    }
+class CommentReactionAPIView(views.APIView):
 
-    return JsonResponse(data, status=200)
+    def put(self, request):
+        serializer = CommentReactionSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-def setNoticeTimestamp(request):
-    data = {
-        "timestamp": "3 Hours ago"
-    }
-    
-    return JsonResponse(data, status=200)
+
+    def patch(self, request):
+        serializer = CommentReactionSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST) 

--- a/backend/notice_project/notice/views.py
+++ b/backend/notice_project/notice/views.py
@@ -45,5 +45,5 @@ class CommentReactionAPIView(views.APIView):
         return Response({
                 "success": False,
                 "data": serializer.data,
-                "message": "Your hreaction could not be updated"
+                "message": "Your reaction could not be updated"
             })


### PR DESCRIPTION
slack name = Daniel

To test
Visit http://noticeboard.zuri.chat/api/comment/reaction/update

Pass the necessary data 

{
"comment_id": 1,
"reaction":"like"
}

This endpoint enables a user to be able to update their reaction under a comment

