### PR TITLE
users should be able to retrieve all created notices resolved #255 

### DIFF
--- a/backend/notice_project/config/settings/base.py
+++ b/backend/notice_project/config/settings/base.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
 
     #installed apps
     'notice',
+    #DRF
     'rest_framework',
 ]
 

--- a/backend/notice_project/notice/models.py
+++ b/backend/notice_project/notice/models.py
@@ -18,3 +18,7 @@ class Notice:
         self.last_modified = last_modified
         # self.parent = parent
 
+class CommentReaction:
+    def __init__(self, comment_id, reaction):
+        self.comment_id = comment_id
+        self.reaction = reaction

--- a/backend/notice_project/notice/serializers.py
+++ b/backend/notice_project/notice/serializers.py
@@ -1,10 +1,11 @@
-from rest_framework import serializers
 from django.utils import timezone
+
+from rest_framework import serializers
 # import uuid
 from .models import Notice
 
 
-class CreateNoticeSerializer(serializers.Serializer):
+class NoticeSerializer(serializers.Serializer):
     
     title = serializers.CharField(max_length=100)
     text = serializers.CharField(max_length=250)

--- a/backend/notice_project/notice/serializers.py
+++ b/backend/notice_project/notice/serializers.py
@@ -2,7 +2,7 @@ from django.utils import timezone
 
 from rest_framework import serializers
 # import uuid
-from .models import Notice
+from .models import Notice, CommentReaction
 
 
 class NoticeSerializer(serializers.Serializer):
@@ -21,3 +21,12 @@ class NoticeSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         return Notice(**validated_data)
+
+
+class CommentReactionSerializer(serializers.Serializer):
+
+    comment_id = serializers.IntegerField()
+    reaction = serializers.CharField(max_length=5)
+
+    def create(self, validated_data):
+        return CommentReaction(**validated_data)

--- a/backend/notice_project/notice/urls.py
+++ b/backend/notice_project/notice/urls.py
@@ -1,18 +1,9 @@
 from django.urls import path
-from .views import sendNotice, viewNotice, setNoticeTimestamp, endpoints,CreateNoticeView
+from .views import NoticeView,CreateNoticeView
 
 #add url routes here
 
 urlpatterns = [
-
-    path("sendNotice/", sendNotice, name="send-notice"),
-
-    path("viewNotice/", viewNotice, name="view-notice"),
-
-    path("setNoticeTimestamp/", setNoticeTimestamp, name="set-notice"),
-    
-    path("endpoints/", endpoints, name="endpoints"),
-
-    path('notices/', CreateNoticeView.as_view()),
-    
+    path('notices/', CreateNoticeView.as_view()), 
+    path('all-notices', NoticeView.as_view(), name='all-notices'),
 ]

--- a/backend/notice_project/notice/urls.py
+++ b/backend/notice_project/notice/urls.py
@@ -1,12 +1,10 @@
 from django.urls import path
-from .views import CreateNoticeView, CommentReactionAPIView
+from .views import CreateNoticeView, CommentReactionAPIView, NoticeView
 
 #add url routes here
 
 urlpatterns = [
-
+    path('all-notices', NoticeView.as_view()),
     path('notices/', CreateNoticeView.as_view()),
-
-    path('comment/reaction/update', CommentReactionAPIView.as_view()),
-    
+    path('comment/reaction/update', CommentReactionAPIView.as_view()), 
 ]

--- a/backend/notice_project/notice/views.py
+++ b/backend/notice_project/notice/views.py
@@ -1,65 +1,117 @@
 from django.shortcuts import render
 from django.http import JsonResponse
-from rest_framework import views
+
+from rest_framework.views import APIView
 from rest_framework import status
 from rest_framework.response import Response
-from .serializers import CreateNoticeSerializer
+
+from .serializers import NoticeSerializer
 
 
 # Create your views here.
-class CreateNoticeView(views.APIView):
+class NoticeView(APIView):
+    """GET request to display/retrieve all existing notices"""
+    def get(self, request):
+        data= [
+        {"id": 1,
+        "title": "Notice Test 1",
+        "text": "Clear at least one issue before the end of the week to be promoted",
+        "photo_url": "null",
+        "video_url": "null",
+        "audio_url": "null",
+        "published": "True"},
+
+        {"id": 2,
+        "title": "Notice Test 2",
+        "text": "Plugin must work without it's own database",
+        "photo_url": "null",
+        "video_url": "null",
+        "audio_url": "null",
+        "published": "True"},
+
+        {"id": 3,
+        "title": "Notice Test 3",
+        "text": "CI/CD must be implemented by DevOps",
+        "photo_url": "null",
+        "video_url": "null",
+        "audio_url": "null",
+        "published": "True"},
+
+        {"id": 4,
+        "title": "Notice Test 4",
+        "text": "Evryone should work individually",
+        "photo_url": "null",
+        "video_url": "null",
+        "audio_url": "null",
+        "published": "True"}
+        ]
+        results = NoticeSerializer(data, many=True).data
+        return Response(results, status=status.HTTP_200_OK)
+
+
+class CreateNoticeView(APIView):
 
     def post(self, request):
-        serializer = CreateNoticeSerializer(data=request.data)
+        serializer = NoticeSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
   
  
+
+
+
+
+
+
+
+
+
+
     
-def home(request):
-    pass
+# def home(request):
+#     pass
 
-def endpoints(request):
-    data = {
-        "viewNotice": "http://localhost:8000/api/viewNotice/",
-        "sendNotice": "http://localhost:8000/api/sendNotice/",
-        "editTimsestamp": "http://localhost:8000/api/setNoticeTimestamp/",
-        "endpoints": "http://localhost:8000/api/endpoints/",
-    }
+# def endpoints(request):
+#     data = {
+#         "viewNotice": "http://localhost:8000/api/viewNotice/",
+#         "sendNotice": "http://localhost:8000/api/sendNotice/",
+#         "editTimsestamp": "http://localhost:8000/api/setNoticeTimestamp/",
+#         "endpoints": "http://localhost:8000/api/endpoints/",
+#     }
 
-    return JsonResponse(data, status=200)
+#     return JsonResponse(data, status=200)
 
-def viewNotice(request):
-    data = {
-        "id": 1,
-        "username": "Bruce Wayne",
-        "date":"24 Hours ago",
-        "timestamp": "3 Hours ago",
-        "views": "21",
-        "likes": "12",
-        "title": "App Testing Event",
-        "info": ""
-    }
+# def viewNotice(request):
+#     data = {
+#         "id": 1,
+#         "username": "Bruce Wayne",
+#         "date":"24 Hours ago",
+#         "timestamp": "3 Hours ago",
+#         "views": "21",
+#         "likes": "12",
+#         "title": "App Testing Event",
+#         "info": ""
+#     }
 
-    return JsonResponse(data, status=200)
+#     return JsonResponse(data, status=200)
 
 
-def sendNotice(request):
-    data = {
-        "username": "Daniel",
-        "recipient": "ZetsuArmy",
-        "title": "Does It Work?",
-        "fileUploaded": "",
-        "message": "Yes, It Works!!!"
-    }
+# def sendNotice(request):
+#     data = {
+#         "username": "Daniel",
+#         "recipient": "ZetsuArmy",
+#         "title": "Does It Work?",
+#         "fileUploaded": "",
+#         "message": "Yes, It Works!!!"
+#     }
 
-    return JsonResponse(data, status=200)
+#     return JsonResponse(data, status=200)
 
-def setNoticeTimestamp(request):
-    data = {
-        "timestamp": "3 Hours ago"
-    }
+# def setNoticeTimestamp(request):
+#     data = {
+#         "timestamp": "3 Hours ago"
+#     }
     
-    return JsonResponse(data, status=200)
+#     return JsonResponse(data, status=200)

--- a/backend/notice_project/notice/views.py
+++ b/backend/notice_project/notice/views.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 from django.shortcuts import render
 from django.http import JsonResponse
 
@@ -7,12 +6,10 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from .serializers import NoticeSerializer
-=======
 from rest_framework import views
 from rest_framework import status
 from rest_framework.response import Response
 from .serializers import CreateNoticeSerializer, CommentReactionSerializer
->>>>>>> 9bc4aa8094d840c568ef418162b341f8b166c997
 
 
 # Create your views here.

--- a/backend/notice_project/notice/views.py
+++ b/backend/notice_project/notice/views.py
@@ -1,15 +1,12 @@
 from django.shortcuts import render
 from django.http import JsonResponse
 
+from rest_framework import views
 from rest_framework.views import APIView
 from rest_framework import status
 from rest_framework.response import Response
 
-from .serializers import NoticeSerializer
-from rest_framework import views
-from rest_framework import status
-from rest_framework.response import Response
-from .serializers import CreateNoticeSerializer, CommentReactionSerializer
+from .serializers import NoticeSerializer, CommentReactionSerializer
 
 
 # Create your views here.
@@ -53,7 +50,7 @@ class NoticeView(APIView):
         return Response(results, status=status.HTTP_200_OK)
 
 
-class CreateNoticeView(APIView):
+class CreateNoticeView(views.APIView):
 
     def post(self, request):
         serializer = NoticeSerializer(data=request.data)
@@ -61,66 +58,6 @@ class CreateNoticeView(APIView):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-<<<<<<< HEAD
-  
- 
-
-
-
-
-
-
-
-
-
-
-    
-# def home(request):
-#     pass
-
-# def endpoints(request):
-#     data = {
-#         "viewNotice": "http://localhost:8000/api/viewNotice/",
-#         "sendNotice": "http://localhost:8000/api/sendNotice/",
-#         "editTimsestamp": "http://localhost:8000/api/setNoticeTimestamp/",
-#         "endpoints": "http://localhost:8000/api/endpoints/",
-#     }
-
-#     return JsonResponse(data, status=200)
-
-# def viewNotice(request):
-#     data = {
-#         "id": 1,
-#         "username": "Bruce Wayne",
-#         "date":"24 Hours ago",
-#         "timestamp": "3 Hours ago",
-#         "views": "21",
-#         "likes": "12",
-#         "title": "App Testing Event",
-#         "info": ""
-#     }
-
-#     return JsonResponse(data, status=200)
-
-
-# def sendNotice(request):
-#     data = {
-#         "username": "Daniel",
-#         "recipient": "ZetsuArmy",
-#         "title": "Does It Work?",
-#         "fileUploaded": "",
-#         "message": "Yes, It Works!!!"
-#     }
-
-#     return JsonResponse(data, status=200)
-
-# def setNoticeTimestamp(request):
-#     data = {
-#         "timestamp": "3 Hours ago"
-#     }
-    
-#     return JsonResponse(data, status=200)
-=======
 
 
 class CommentReactionAPIView(views.APIView):
@@ -155,4 +92,3 @@ class CommentReactionAPIView(views.APIView):
                 "data": serializer.data,
                 "message": "Your reaction could not be updated"
             })
->>>>>>> 9bc4aa8094d840c568ef418162b341f8b166c997


### PR DESCRIPTION
<h3>slack name : Mob</h3>
<h1>Description</h1>
The created endpoint sends a GET request that retrieves all existing notices and the information they hold.

<h2>Test with the live link:</h2>
Visit  http://noticeboard.zuri.chat/api/all-notices
