### PR TITLE
users can retrieve/view all created notices resolved #255 

### DIFF
--- a/backend/notice_project/notice/urls.py
+++ b/backend/notice_project/notice/urls.py
@@ -7,6 +7,8 @@ urlpatterns = [
 
     path('notices/', CreateNoticeView.as_view()),
 
+    path('all-notices', CreateNoticeView.as_view()),
+
     path('comment/reaction/update', CommentReactionAPIView.as_view()),
     
 ]

--- a/backend/notice_project/notice/urls.py
+++ b/backend/notice_project/notice/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import CreateNoticeView, CommentReactionAPIView
+from .views import CreateNoticeView, CommentReactionAPIView, AllNoticesView
 
 #add url routes here
 
@@ -7,7 +7,7 @@ urlpatterns = [
 
     path('notices/', CreateNoticeView.as_view()),
 
-    path('all-notices', CreateNoticeView.as_view()),
+    path('all-notices', AllNoticesView.as_view()),
 
     path('comment/reaction/update', CommentReactionAPIView.as_view()),
     

--- a/backend/notice_project/notice/views.py
+++ b/backend/notice_project/notice/views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from .serializers import CreateNoticeSerializer, CommentReactionSerializer
 import requests
 
-class CreateNoticeView(views.APIView):
+class AllNoticesView(views.APIView):
 
     """GET request to display/retrieve all existing notices"""
     def get(self, request):
@@ -33,7 +33,8 @@ class CreateNoticeView(views.APIView):
         return Response(results, status=status.HTTP_200_OK)
 
 
-    """POST request to create a new notice"""
+class CreateNoticeView(views.APIView):
+
     def post(self, request):
         serializer = CreateNoticeSerializer(data=request.data)
         if serializer.is_valid():

--- a/backend/notice_project/notice/views.py
+++ b/backend/notice_project/notice/views.py
@@ -6,6 +6,34 @@ import requests
 
 class CreateNoticeView(views.APIView):
 
+    """GET request to display/retrieve all existing notices"""
+    def get(self, request):
+        data= [
+        {"title":"Management meeting",
+        "text":"Management has updated the design scedule",
+        "photo_url":"null",
+        "video_url":"null",
+        "audio_url":"null"},
+
+        {"title":"Stage 5",
+        "text":"Complete a ticket to move to stage 5",
+        "photo_url":"null",
+        "video_url":"null",
+        "audio_url":"null",
+        "published":"True"},
+
+        {"title":"Individual work",
+        "text":"Each intern is expected to complete at least one ticket individually",
+        "photo_url":"null",
+        "video_url":"null",
+        "audio_url":"null"},
+        ]
+        
+        results = CreateNoticeSerializer(data, many=True).data
+        return Response(results, status=status.HTTP_200_OK)
+
+
+    """POST request to create a new notice"""
     def post(self, request):
         serializer = CreateNoticeSerializer(data=request.data)
         if serializer.is_valid():


### PR DESCRIPTION
<h3>slack name: Mob</h3>

<h1>Description</h1>
The created endpoint sends a GET request that retrieves all existing notices and the information they hold.

<h2>Test with the live link:</h2>
Visit http://noticeboard.zuri.chat/api/all-notices